### PR TITLE
Id will be now be received from <iframe name> attribute

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 /* eslint-env node */
 module.exports = {
   "root": true,
-  "ignorePatterns": ['*.config.js', '*.spec.js', 'tasks/*'],
+  "ignorePatterns": ['*.config.js', '*.spec.js', 'tasks/*', 'dist/*'],
   "extends": [
     "plugin:vue/vue3-essential",
     "eslint:recommended"

--- a/src/core/injector/core/launcher.spec.js
+++ b/src/core/injector/core/launcher.spec.js
@@ -8,7 +8,12 @@ describe('$init', () => {
 
   beforeEach(() => {
     global.window.addEventListener = jest.fn();
+    global.window.name = 'XXX';
     global.setInterval = jest.fn();
+    global.crypto = {
+      getRandomValues: jest.fn(() => ['abc']),
+    };
+
 
     injector = {
       listen: jest.fn(),
@@ -49,7 +54,7 @@ describe('$init', () => {
 
     it('should emit "$size" event', () => {
       handler({}, {});
-      expect(injector.emit.mock.calls[1]).toEqual(['$size', 'SIZE']);
+      expect(injector.emit.mock.calls[2]).toEqual(['$size', 'SIZE']);
     });
 
     it('should get sizes from $size method', () => {
@@ -87,13 +92,13 @@ describe('$init', () => {
     it('should emit proper listener event', () => {
       handler({ detail: { type: 'event_name', data: { foo: 'bar' } } });
 
-      expect(injector.emit.mock.calls[1]).toEqual(['event_name', { foo: 'bar' }]);
+      expect(injector.emit.mock.calls[2]).toEqual(['event_name', { foo: 'bar' }]);
     });
 
     it('should fill size for $size type', () => {
       handler({ detail: { type: '$size' } });
 
-      expect(injector.emit.mock.calls[1]).toEqual(['$size', 'SIZE']);
+      expect(injector.emit.mock.calls[2]).toEqual(['$size', 'SIZE']);
     });
   });
 

--- a/src/core/injector/index.js
+++ b/src/core/injector/index.js
@@ -2,10 +2,10 @@ import Core from './core/Core';
 import injectorFactory from './core/injectorFactory';
 import launch from './core/launcher';
 
-export default () => {
+export default (options = {}) => {
   const core = new Core();
   const injector = injectorFactory(core);
-  launch(injector, core);
+  launch(injector, core, options);
 
   return injector;
 }

--- a/src/core/injector/index.spec.js
+++ b/src/core/injector/index.spec.js
@@ -33,6 +33,6 @@ describe('createInjector', () => {
   });
 
   it('should launch an injector', () => {
-    expect(launcher).toHaveBeenCalledWith('INJECTOR', { core: 'CORE' });
+    expect(launcher).toHaveBeenCalledWith('INJECTOR', { core: 'CORE' }, {});
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export const Tab = tab;
 export const Pad = pad;
 export const Card = card;
 
-export default (widgets) => {
+export default (widgets = {}, options = {}) => {
   const boiler = createBoiler();
   boiler.plugin(boilerVuePlugin);
   boiler.store(busVuePlugin($bus()));
@@ -22,5 +22,5 @@ export default (widgets) => {
 
   for (const widget in widgets) boiler.mount(widget, widgets[widget]);
 
-  return $injector();
+  return $injector(options);
 };


### PR DESCRIPTION
1. Now to make experience with multiple slots on a page at most smooth use iframe 'name' attribute to pass an id. Otherwise it will be self-assigned and raised to parent app with '$created' event - but this requires additional handling
2. To disable auto-resizing events pass a second argument (options) to a `createApp` main exported function as an object with prop `disableAutoResizing` set to `true`: `createApp({...}, { disableAutoResizing: true })`