### PR TITLE
Mount widgets with Shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblueconnect/connect-ui-toolkit",
-  "version": "26.0.9",
+  "version": "26.1.0",
   "main": "dist/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/src/core/boiler-plugins/vue-plugin.js
+++ b/src/core/boiler-plugins/vue-plugin.js
@@ -28,6 +28,15 @@ export const create = (boiler, component, storeInstaller) => {
     watch: (prop, newVal) => (state[prop] = newVal),
     mount: (el) => app.mount(el),
     unmount: () => app.unmount(),
+    css: () => {
+      // This function gathers css for a component
+      // In vue case we gather inline css from a component itself and ones from components it extends
+      let styles = '';
+      if (Array.isArray(component?.styles)) styles += component.styles.join('');
+      if (Array.isArray(component?.extends?.styles)) styles += component.extends.styles.join('');
+
+      return styles;
+    },
   }
 }
 

--- a/src/core/boiler-plugins/vue-plugin.js
+++ b/src/core/boiler-plugins/vue-plugin.js
@@ -10,10 +10,10 @@ export const observe = component => {
 }
 
 export const create = (boiler, component, storeInstaller) => {
-  const customs = [...(boiler?.settings?.customs || []), 'content'];
+  const customs = [...(boiler?.settings?.customs || []), 'boiler-content'];
   const state = reactive(boiler.getState());
   const app = createApp({
-    template: `<widget v-bind="state">${boiler.content}</widget>`,
+    template: `<widget v-bind="state"><boiler-content></boiler-content></widget>`,
     computed: { state: () => state },
   });
 
@@ -26,7 +26,7 @@ export const create = (boiler, component, storeInstaller) => {
 
   return {
     watch: (prop, newVal) => (state[prop] = newVal),
-    mount: () => app.mount(boiler.element),
+    mount: (el) => app.mount(el),
     unmount: () => app.unmount(),
   }
 }

--- a/src/core/boiler-plugins/vue-plugin.spec.js
+++ b/src/core/boiler-plugins/vue-plugin.spec.js
@@ -201,4 +201,21 @@ describe('create', () => {
       expect(app.unmount).toHaveBeenCalled();
     });
   });
+
+  describe('css', () => {
+    it.each([
+      [undefined, undefined, ''],
+      ['foo', undefined, 'foo'],
+      [undefined, 'bar', 'bar'],
+      ['foo', 'bar', 'foobar'],
+    ])('When styles %j and extended %j should return %j', (style, extend, expected) => {
+      component = {};
+      if (style) component.styles = [style];
+      if (extend) component.extends = { styles: [extend] };
+
+      call();
+
+      expect(result.css()).toEqual(expected);
+    });
+  });
 });

--- a/src/core/boiler-plugins/vue-plugin.spec.js
+++ b/src/core/boiler-plugins/vue-plugin.spec.js
@@ -95,10 +95,10 @@ describe('create', () => {
     it.each([
       [{ customs: ['foo', 'bar'] }, 'foo', true],
       [{ customs: ['foo', 'bar'] }, 'bar', true],
-      [{ customs: ['foo', 'bar'] }, 'content', true],
+      [{ customs: ['foo', 'bar'] }, 'boiler-content', true],
       [{ customs: ['foo'] }, 'bar', false],
-      [{}, 'content', true],
-      [null, 'content', true],
+      [{}, 'boiler-content', true],
+      [null, 'boiler-content', true],
     ])('for %j customs %j should be %j', (settings, tag, res) => {
       boiler.settings = settings;
       call();
@@ -122,7 +122,7 @@ describe('create', () => {
 
     it('should bind state to a newly created app', () => {
       expect(createApp).toHaveBeenCalledWith({
-        template: '<widget v-bind=\"state\"><foo>bar</foo></widget>',
+        template: '<widget v-bind=\"state\"><boiler-content></boiler-content></widget>',
         computed: { state: expect.any(Function) },
       });
     });

--- a/src/core/boiler/core/helpers.js
+++ b/src/core/boiler/core/helpers.js
@@ -38,3 +38,5 @@ export const $emit = (el, name, input) => {
   const event = new CustomEvent(name, { bubbles: true, detail: { input } });
   el.dispatchEvent(event);
 }
+
+export const hex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');

--- a/src/core/boiler/core/widgetFactory.js
+++ b/src/core/boiler/core/widgetFactory.js
@@ -27,11 +27,13 @@ export default (plugin, component, storeInstaller, settings) => class Widget ext
       watch = noop,
       mount = noop,
       unmount = noop,
+      css = noop,
     } = plugin.create(boilerInterface(this, component, plugin), component, storeInstaller);
 
     this.mount = mount;
     this.unmount = unmount;
     this.watch = watch;
+    this.css = css;
   }
 
   connectedCallback() {
@@ -59,12 +61,12 @@ export default (plugin, component, storeInstaller, settings) => class Widget ext
       handler(e.detail);
     });
 
-    // Ugly-ugly solution to make Shadow DOM transparent in terms of styling
-    // If you have ANY more appropriate idea - please contact me
-    const styles = document.querySelectorAll('style');
-    styles.forEach((el) => {
-      this.$shadow.appendChild(el.cloneNode(true));
-    });
+    // Solution to configure styles of shadow zone properly
+    // css function should return a css string that will stylize this particular zone
+    // plugin is responsible for supplying this - so logic therein may be very custom
+    const style = document.createElement('style');
+    style.append(this.css());
+    this.$shadow.appendChild(style);
 
     // Default slot positioning -
     // covers situation when mount doesn't wipe out content nodes

--- a/src/core/boiler/core/widgetFactory.spec.js
+++ b/src/core/boiler/core/widgetFactory.spec.js
@@ -15,10 +15,12 @@ jest.mock('./boilerInterface', () => ({
 jest.mock('./helpers', () => ({
   noop: jest.fn(),
   $updateAttribute: jest.fn(),
+  hex: jest.fn(() => 'aaaaaaaa'),
 }))
 
 describe('widgetFactory', () => {
   let Widget;
+  let shadow;
   let widget;
   let plugin;
   let pluginWatch;
@@ -29,7 +31,19 @@ describe('widgetFactory', () => {
   let settings;
 
   beforeEach(() => {
-    global.HTMLElement = class {};
+    shadow = {
+      querySelector: jest.fn(() => ({
+        replaceWith: jest.fn(),
+      })),
+      appendChild: jest.fn(),
+      getElementById: jest.fn(() => null),
+    };
+
+    global.HTMLElement = class {
+      constructor() {
+        this.attachShadow = jest.fn(() => shadow);
+      }
+    };
 
     pluginWatch = jest.fn();
     pluginMount = jest.fn();

--- a/src/core/boiler/core/widgetFactory.spec.js
+++ b/src/core/boiler/core/widgetFactory.spec.js
@@ -237,23 +237,31 @@ describe('widgetFactory', () => {
 
       beforeEach(() => {
         styleElement = {
-          cloneNode: jest.fn(() => 'foo'),
+          foo: 'bar',
+          append: jest.fn(),
+          setAttribute: jest.fn(),
+          appendChild: jest.fn(),
         };
 
-        global.document.querySelectorAll = jest.fn(() => [styleElement]);
+        global.document.createElement = jest.fn(() => styleElement);
+        widget.css = jest.fn(() => 'foo');
         widget.connectedCallback();
       });
 
-      it('should pick all "style" nodes', () => {
-        expect(document.querySelectorAll).toHaveBeenCalledWith('style');
+      it('should create style node', () => {
+        expect(document.createElement).toHaveBeenCalledWith('style');
       });
 
-      it('should clone "style" nodes', () => {
-        expect(styleElement.cloneNode).toHaveBeenCalledWith(true);
+      it('should take given styles', () => {
+        expect(widget.css).toHaveBeenCalled();
       });
 
-      it('should paste copied node to shadow DOM zone', () => {
-        expect(widget.$shadow.appendChild.mock.calls[0][0]).toBe('foo');
+      it('should place given css to "style" node', () => {
+        expect(styleElement.append).toHaveBeenCalledWith('foo');
+      });
+
+      it('should paste created style node to shadow', () => {
+        expect(widget.$shadow.appendChild.mock.calls[0][0]).toEqual(expect.objectContaining({ foo: 'bar' }));
       });
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,12 @@ module.exports = {
     rules: [
       {
         test: /\.vue$/,
-        use: 'vue-loader'
+        use: {
+          loader: 'vue-loader',
+          options: {
+            customElement: true,
+          },
+        },
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
This will align experience of using widgets inside plain JS apps as well as complex SPA's with own lifecycle
In fact now instead of mounting an app on a widget element directly it mounts it inside a shadow DOM zone inside it. Content that is provided from outside is now put into a slot that app navigates to a particular place where it suppose to be rendered. This means content and widget are handled separately although they are displayed one inside another.

*there is a quite raw solution for passing styles to shadow DOM sections. I hope I will come up with something more clean down the road