### PR TITLE
Serve toolkit files directly on development mode when running the dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "26.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
-    "start": "node tasks/start.js",
+    "build": "NODE_ENV=production webpack --config webpack.config.js",
+    "start": "NODE_ENV=development node tasks/start.js",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 const { resolve } = require("path");
 
 module.exports = {
-  mode: 'production',
+  mode: process.env.NODE_ENV,
+
   experiments: {
     outputModule: true,
   },
@@ -79,8 +80,10 @@ module.exports = {
       "Access-Control-Allow-Origin": "*",
     },
 
+    static: ['dist'],
+
     historyApiFallback: {
-      index: '/',
+      rewrites: [{ from: /./, to: '/index.js' }],
     },
   },
-}
+};


### PR DESCRIPTION
This PR changes the webpack's devServer config so it exposes the built files directly on the development server url.

This means that we can import the toolkit, while running the dev server, either via `<script type="module" src="http://localhost:3003"></script>` when used directly in an html file, or via the `import` function in any js module (`import('http://localhost:3003').then(module => ... )`) or in webpack (`import(/* webpackIgnore: true */'http://localhost:3003').then(module => ... )`).

Also configured webpack to set `mode` to the value of `NODE_ENV` environment variable, so we can run the dev server on `development` mode and the build task on `production` mode.