### PR TITLE
LITE-29547: Control if next & previous actions are allowed in fast API adapter & fix export config for tools

### DIFF
--- a/components/src/index.js
+++ b/components/src/index.js
@@ -1,42 +1,26 @@
-import $injector from './core/injector';
-import registerWidget from './core/registerWidget';
+import $injector from '~core/injector';
+import registerWidget from '~core/registerWidget';
 
-import tabs from './widgets/tabs/widget.vue';
-import tab from './widgets/tab/widget.vue';
-import pad from './widgets/pad/widget.vue';
-import card from './widgets/card/widget.vue';
-import icon from './widgets/icon/widget.vue';
-import view from './widgets/view/widget.vue';
-import navigation from './widgets/navigation/widget.vue';
-import status from './widgets/status/widget.vue';
-import textfield from './widgets/textfield/widget.vue';
-import table from './widgets/table/widget.vue';
-import button from './widgets/button/widget.vue';
-import complexTable from './widgets/complexTable/widget.vue';
 
-import _store from './core/store';
-import _bus from './core/eventBus';
-import {
-  connectPortalRoutesDict,
-} from './constants/portal-routes';
+export { default as Tabs } from '~widgets/tabs/widget.vue';
+export { default as Tab } from '~widgets/tab/widget.vue';
+export { default as Pad } from '~widgets/pad/widget.vue';
+export { default as Card } from '~widgets/card/widget.vue';
+export { default as Icon } from '~widgets/icon/widget.vue';
+export { default as View } from '~widgets/view/widget.vue';
+export { default as Navigation } from '~widgets/navigation/widget.vue';
+export { default as Status } from '~widgets/status/widget.vue';
+export { default as Textfield } from '~widgets/textfield/widget.vue';
+export { default as Table } from '~widgets/table/widget.vue';
+export { default as ComplexTable } from './widgets/complexTable/widget.vue';
+export { default as Button } from '~widgets/button/widget.vue';
 
-export const Tabs = tabs;
-export const Tab = tab;
-export const Pad = pad;
-export const Card = card;
-export const Icon = icon;
-export const View = view;
-export const Navigation = navigation;
-export const Status = status;
-export const Textfield = textfield;
-export const Table = table;
-export const Button = button;
-export const ComplexTable = complexTable;
+export { default as store } from '~core/store';
+export { default as bus } from '~core/eventBus';
 
-export const bus = _bus;
-export const store = _store;
-
-export const connectPortalRoutes = connectPortalRoutesDict;
+export {
+  connectPortalRoutesDict as connectPortalRoutes,
+} from '~constants/portal-routes';
 
 export default (widgets = {}, options = {}) => {
   for (const widget in widgets) registerWidget(widget, widgets[widget]);

--- a/components/webpack.config.js
+++ b/components/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     outputModule: true,
   },
 
-  entry: path.resolve(__dirname, './src/index.js'),
+  entry: path.resolve(__dirname, 'src/index.js'),
 
   output: {
     path: path.resolve(__dirname, '..', 'dist'),
@@ -37,7 +37,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        include: [path.resolve('app'), path.resolve('test')],
+        include: [path.resolve(__dirname, 'src'), path.resolve('test')],
         exclude: /node_modules/,
       },
       {
@@ -61,9 +61,9 @@ module.exports = {
 
   resolve: {
     alias: {
-      '~core': path.resolve(__dirname, './src/core'),
-      '~widgets': path.resolve(__dirname, './src/widgets'),
-      '~constants': path.resolve(__dirname, './src/constants'),
+      '~core': path.resolve(__dirname, 'src/core'),
+      '~widgets': path.resolve(__dirname, 'src/widgets'),
+      '~constants': path.resolve(__dirname, 'src/constants'),
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "30.1.0",
   "exports": {
     ".": "./dist/index.js",
-    "./tools": "./dist/tools"
+    "./tools/*": "./dist/tools/*"
   },
   "scripts": {
     "build": "NODE_ENV=production webpack --config ./webpack.config.js",
     "build:core": "NODE_ENV=production webpack --config ./components/webpack.config.js",
     "build:tools": "NODE_ENV=production webpack --config ./tools/webpack.config.js",
-    "start": "NODE_ENV=development webpack serve",
+    "start": "NODE_ENV=development webpack serve --config ./webpack-dev.config.js",
     "start:https": "npm run start -- --server-type https",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "test": "jest --config ./jest.config.js",

--- a/tools/api/fastApi/adapter.js
+++ b/tools/api/fastApi/adapter.js
@@ -54,18 +54,22 @@ export const fastApiTableAdapter = (endpoint, rowsPerPage = 10) => {
   };
 
   /**
-   * @returns {Promise<{total: number, page: number, items: *[]}>}
+   * @returns {{total: number, page: number, items: *[]}|Promise<{total: number, page: number, items: *[]}>}
    */
   const next = () => {
+    if (state.page >= Math.ceil(state.total / limit)) return state;
+
     state.page++;
 
     return load();
   };
 
   /**
-   * @returns {Promise<{total: number, page: number, items: *[]}>}
+   * @returns {{total: number, page: number, items: *[]}|Promise<{total: number, page: number, items: *[]}>}
    */
   const previous = () => {
+    if (state.page <= 1) return state;
+
     state.page--;
 
     return load();

--- a/tools/api/fastApi/index.js
+++ b/tools/api/fastApi/index.js
@@ -1,2 +1,0 @@
-export { fastApiTableAdapter } from './adapter';
-export { fastApiTableAdapterComposable } from './vue-composable';

--- a/tools/api/fastApi/vue-composable.js
+++ b/tools/api/fastApi/vue-composable.js
@@ -11,7 +11,7 @@ import { fastApiTableAdapter } from './adapter';
  *
  * @returns {{next: ((function(): Promise<void>)|*), filter: ((function(*): Promise<void>)|*), total: Ref<UnwrapRef<number>>, load: ((function(): Promise<void>)|*), previous: ((function(): Promise<void>)|*), setRowsPerPage: ((function(*): Promise<void>)|*), page: Ref<UnwrapRef<number>>, loading: Ref<UnwrapRef<boolean>>, items: Ref<UnwrapRef<[]>>}}
  */
-export const fastApiTableAdapterComposable = (endpoint, rowsPerPage = 10) => {
+export const useFastApiTableAdapter = (endpoint, rowsPerPage = 10) => {
   const adapter = fastApiTableAdapter(endpoint, rowsPerPage);
 
   const items = ref(adapter.items);

--- a/tools/api/fastApi/vue-composable.spec.js
+++ b/tools/api/fastApi/vue-composable.spec.js
@@ -1,4 +1,4 @@
-import { fastApiTableAdapterComposable } from './vue-composable';
+import { useFastApiTableAdapter } from './vue-composable';
 import { fastApiTableAdapter } from './adapter';
 
 
@@ -23,13 +23,13 @@ jest.mock('./adapter', () => ({
   }),
 }));
 
-describe('#fastApiTableAdapterComposable', () => {
+describe('#useFastApiTableAdapter', () => {
   let composable;
   let adapter;
 
   describe('#constructor', () => {
     beforeEach(() => {
-      composable = fastApiTableAdapterComposable('/foo');
+      composable = useFastApiTableAdapter('/foo');
     });
 
     it('creates a new fastApiTableAdapter', () => {
@@ -52,7 +52,7 @@ describe('#fastApiTableAdapterComposable', () => {
 
   describe('methods', () => {
     beforeEach(() => {
-      composable = fastApiTableAdapterComposable('/foo', 10);
+      composable = useFastApiTableAdapter('/foo', 10);
       adapter = composable._adapter;
     });
 

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -9,9 +9,13 @@ module.exports = {
   },
 
   entry: {
-    fastApi: {
-      import: path.resolve(__dirname, 'api/fastApi/index.js'),
-      filename: 'tools/[name].js',
+    fastApiAdapter: {
+      import: path.resolve(__dirname, 'api/fastApi/adapter.js'),
+      filename: 'tools/fastApi/index.js',
+    },
+    fastApiAdapterVue: {
+      import: path.resolve(__dirname, 'api/fastApi/vue-composable.js'),
+      filename: 'tools/fastApi/vue.js',
     },
   },
 
@@ -30,5 +34,9 @@ module.exports = {
         exclude: /node_modules/,
       },
     ],
+  },
+
+  externals: {
+    vue: 'vue',
   },
 };

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -1,0 +1,23 @@
+const configs = require('./webpack.config');
+const { parallelism } = require('./webpack.config');
+
+
+const devServerConfig = {
+  devServer: {
+    compress: true,
+    port: process.env.PORT || 3003,
+    allowedHosts: 'all',
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+    },
+    static: false,
+  },
+};
+
+module.exports = [
+  devServerConfig,
+  ...configs,
+];
+
+
+module.exports.parallelism = parallelism;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,19 +4,7 @@ const componentsConfig = require('./components/webpack.config');
 const toolsConfig = require('./tools/webpack.config');
 
 
-const devServerConfig = {
-  devServer: {
-    compress: true,
-    port: process.env.PORT || 3003,
-    allowedHosts: 'all',
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-    },
-  },
-};
-
 module.exports = [
-  devServerConfig,
   componentsConfig,
   toolsConfig,
 ];


### PR DESCRIPTION
- Added conditions to not perform a request is there is no next page or no previous page in the `fastApiTableAdapter` module.
- Fixed tools export in `package.json`, previous config was not correct. Works fine now.
- Split build and dev (serve) Webpack configs in two files to have a clean configuration when building the project.
- Changed tools' Webpack config: Removed `index` export, opting for having two separate files exposed: one for the adapter and one for the composable, so Vue is not required when using the base adapter. Vue is declared as an external dependency, which means it is not bundled with the tools' exports, and it will rely instead on the version of Vue used by the end user.
- Cleaned up main export, exporting everything directly. Way more readable and clear.

---

With this PR there are no changes required to use the fastApiTableAdapter:
```js
import { fastApiTableAdapter } from '@cloudblueconnect/connect-ui-toolkit/tools/fastApi';
```

But to use the Vue composable for the adapter you need to:
```js
import { useFastApiTableAdapter } from '@cloudblueconnect/connect-ui-toolkit/tools/fastApi/vue';
```