### PR TITLE
Add .npmignore file to select which files need to be packed when publishing the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Ignore everything
+*
+
+# Except
+
+# Distribution files
+!/dist/**/*
+
+# License file, package.json and readme
+!LICENSE
+!package.json
+!README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudblueconnect/connect-ui-toolkit",
-  "version": "30.2.0",
+  "version": "30.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudblueconnect/connect-ui-toolkit",
-      "version": "30.2.0",
+      "version": "30.2.1",
       "dependencies": {
         "@cloudblueconnect/material-svg": "^1.0.42",
         "mitt": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblueconnect/connect-ui-toolkit",
-  "version": "30.2.0",
+  "version": "30.2.1",
   "exports": {
     ".": "./dist/index.js",
     "./tools/*": "./dist/tools/*"


### PR DESCRIPTION
Publishing process broke when I updated the version for the Github action we use to publish the toolkit to NPM.

For reasons that I don't understand, the previous version of the action ignored the contents of `.gitignore`, which was fixed in newer versions. However, our process relied on that incorrect step. I created the `.npmignore` file to pick which files are published to NPM. This means to ignore everything but files under `/dist` directory (created when running `npm run build`) and `LICENSE`, `README.md` and `package.json` files. I think that it does not make sense to have all the project files available when installing the package, but let me know if you'd prefer it this way.

Also updated the package version to 30.2.1