### PR TITLE
Feature/lite 29476 create menu component

### DIFF
--- a/components/src/assets/styles/variables.styl
+++ b/components/src/assets/styles/variables.styl
@@ -1,1 +1,2 @@
 border-color = #e0e0e0;
+base-text-color = #212121;

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -14,6 +14,7 @@ export { default as Textfield } from '~widgets/textfield/widget.vue';
 export { default as Table } from '~widgets/table/widget.vue';
 export { default as ComplexTable } from './widgets/complexTable/widget.vue';
 export { default as Button } from '~widgets/button/widget.vue';
+export { default as Menu } from '~widgets/menu/widget.vue';
 
 export { default as store } from '~core/store';
 export { default as bus } from '~core/eventBus';

--- a/components/src/stories/Menu.stories.js
+++ b/components/src/stories/Menu.stories.js
@@ -1,0 +1,31 @@
+import Menu from '~widgets/menu/widget.vue';
+import Button from '~widgets/button/widget.vue';
+import registerWidget from '~core/registerWidget';
+
+registerWidget('ui-menu', Menu);
+registerWidget('ui-button', Button);
+
+export const Component = {
+  render: (args) => ({
+    setup() {
+      return {args};
+    },
+    template: `<ui-menu>
+    <ui-button 
+      slot="trigger" 
+      text="open menu" 
+    />
+    <div style="padding:8px 16px; width:300px; border:1px solid black;" slot="content">
+      <p>item</p>
+    </div>
+  </ui-menu>`
+  }),
+};
+
+export default {
+  title: 'Components/Menu',
+  component: Menu,
+  parameters: {
+    layout: 'centered',
+  },
+};

--- a/components/src/widgets/menu/widget.spec.js
+++ b/components/src/widgets/menu/widget.spec.js
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils'
+import Menu from './widget';
+
+describe('Menu component', () => {
+  describe('methods', () => {
+    describe('#toggle', () => {
+      it('toggles menu to true when clicking', () => {
+        const wrapper = mount(Menu);
+        wrapper.vm.showMenu = false;
+        wrapper.vm.toggle(wrapper.vm.showMenu);
+
+        expect(wrapper.vm.showMenu).toBe(true);
+      });
+
+      it('toggles menu back to false when clicking', () => {
+        const wrapper = mount(Menu);
+        wrapper.vm.showMenu = true;
+        wrapper.vm.toggle(wrapper.vm.showMenu);
+
+        expect(wrapper.vm.showMenu).toBe(false);
+      });
+    });
+
+    describe('#handleClickOutside', () => {
+
+      it('hides menu content when clicked outside menu', () => {
+        const event = { target: 'another value'};
+        const wrapper = mount(Menu);
+        wrapper.vm.menu = { contains: jest.fn().mockReturnValue(false) };
+        wrapper.vm.showMenu = true;
+        wrapper.vm.handleClickOutside(event);
+
+        expect(wrapper.vm.showMenu).toBe(false);
+      });
+
+      it('does not hide menu content when clicked inside menu', () => {
+        const event = { target: 'some value'};
+        const wrapper = mount(Menu);
+        wrapper.vm.menu = { contains: jest.fn().mockReturnValue(true) };
+        wrapper.vm.showMenu = true;
+        wrapper.vm.handleClickOutside(event);
+
+        expect(wrapper.vm.showMenu).toBe(true);
+      });
+    });
+  });
+
+  describe('onMounted', () => {
+    it('adds up event listener on component mount', () => {
+      const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+  
+      mount(Menu);
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  
+      addEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe('onUnmounted', () => {
+    it('cleans up event listener on component unmount', async () => {
+      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+  
+      const wrapper = mount(Menu);
+      await wrapper.unmount();
+  
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  
+      removeEventListenerSpy.mockRestore();
+    });
+  })
+});

--- a/components/src/widgets/menu/widget.vue
+++ b/components/src/widgets/menu/widget.vue
@@ -1,0 +1,61 @@
+<template>
+  <div
+    ref="menu"
+    class="menu"
+  >
+    <div 
+      class="menu-trigger" 
+      @click.stop="toggle"
+    >
+      <slot name="trigger" />
+    </div>
+    
+    <div class="menu-content-wrapper">
+      <div 
+        v-if="showMenu"
+        class="menu-content"
+        @click.stop
+      >
+        <slot name="content" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { onMounted, onUnmounted, ref } from 'vue'
+
+  const showMenu = ref(false)
+  const menu = ref(null)
+
+  const toggle = () => {
+    showMenu.value = !showMenu.value;
+  }
+
+  const handleClickOutside = (event) => {
+    if (menu.value && !menu.value.contains(event.target)) {
+      showMenu.value = false;
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener("click", handleClickOutside)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener("click", handleClickOutside)
+  })
+</script>
+
+<style lang="stylus" scoped>
+
+  .menu-content-wrapper {
+    position: relative;
+  }
+
+  .menu-content {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+</style>

--- a/components/src/widgets/textfield/widget.vue
+++ b/components/src/widgets/textfield/widget.vue
@@ -61,6 +61,8 @@ export default {
 </script>
 
 <style lang="stylus">
+@import '../../assets/styles/common.styl';
+
 .text-field {
   font-family: 'Roboto';
   font-size: 14px;
@@ -68,7 +70,7 @@ export default {
   font-weight: 400;
   display: flex;
   flex-flow: column nowrap;
-  color: #212121;
+  color: base-text-color;
 
   label {
     font-weight 500;


### PR DESCRIPTION
Added basic version of menu component

Both the button and container for item are customisable, as they are just plain slot elements (so the styles here are of course not important:) )
<img width="577" alt="Screenshot 2024-02-19 at 14 08 15" src="https://github.com/cloudblue/connect-ui-toolkit/assets/52078551/65344a9b-751e-4561-9126-c389002a9c44">
