### PR TITLE
Fix view component's content display

### DIFF
--- a/components/src/widgets/view/widget.vue
+++ b/components/src/widgets/view/widget.vue
@@ -127,7 +127,7 @@ export default {
   flex: 1 1 100%;
   display: grid;
 
-  grid-template-rows: auto auto;
+  grid-template-rows: min-content auto;
   grid-template-columns: 1fr;
   grid-template-areas: "n" "c";
 


### PR DESCRIPTION
Minor fix to properly display the View component.

Now (👍):
<img width="1153" alt="Screenshot 2024-02-21 at 16 41 49" src="https://github.com/cloudblue/connect-ui-toolkit/assets/50662025/594a46da-d117-40c3-b2b8-2d3bc78d0af2">

Before (👎):
<img width="1153" alt="Screenshot 2024-02-21 at 16 41 36" src="https://github.com/cloudblue/connect-ui-toolkit/assets/50662025/57a1eab7-38c5-437a-9143-505974b589ef">
