### PR TITLE
Refactor $size event behavior

### DIFF
--- a/components/src/core/injector/core/Core.js
+++ b/components/src/core/injector/core/Core.js
@@ -21,11 +21,4 @@ export default class {
 
     if (has('*', this.watchers)) this.watchers['*'].forEach(call);
   }
-
-  size() {
-    return {
-      height: Math.max(document.documentElement.offsetHeight, document.documentElement.scrollHeight),
-      width: Math.max(document.documentElement.offsetWidth, document.documentElement.scrollWidth),
-    };
-  }
 }

--- a/components/src/core/injector/core/Core.spec.js
+++ b/components/src/core/injector/core/Core.spec.js
@@ -82,18 +82,4 @@ describe('Core', () => {
       expect(core.watchers['*'][0]).toHaveBeenCalled();
     });
   });
-
-  describe('#size', () => {
-    it('should return document size in proper format', () => {
-      jest.spyOn(global.document.documentElement, 'scrollHeight', 'get').mockReturnValue(100)
-      jest.spyOn(global.document.documentElement, 'scrollWidth', 'get').mockReturnValue(300)
-      jest.spyOn(global.document.documentElement, 'offsetHeight', 'get').mockReturnValue(200)
-      jest.spyOn(global.document.documentElement, 'offsetWidth', 'get').mockReturnValue(200)
-
-      expect(core.size()).toEqual({
-        width: 300,
-        height: 200,
-      });
-    });
-  });
 });

--- a/components/src/core/injector/core/launcher.js
+++ b/components/src/core/injector/core/launcher.js
@@ -10,8 +10,12 @@ export default (injector, core, options = {}) => new Promise((resolve) => {
     core.state = data;
 
     if (!options?.disableAutoResizing) {
-      injector.emit('$size', core.size());
-      setInterval(() => injector.emit('$size', core.size()), 300);
+      const resizeObserver = new ResizeObserver((entries) => {
+        const [{ contentRect }] = entries;
+        injector.emit('$size', { height: contentRect.height, width: contentRect.width });
+      });
+
+      resizeObserver.observe(document.body);
     }
 
     resolve();
@@ -20,7 +24,10 @@ export default (injector, core, options = {}) => new Promise((resolve) => {
   window.addEventListener('$injector', ({ detail }) => {
     let { type, data } = detail;
 
-    if (type === '$size') data = core.size();
+    if (type === '$size') {
+      const { height, width } = document.body.getBoundingClientRect();
+      data = { height, width };
+    }
 
     injector.emit(type, data);
   });

--- a/components/src/widgets/view/widget.vue
+++ b/components/src/widgets/view/widget.vue
@@ -149,6 +149,7 @@ export default {
   &__content-holder {
     position: relative;
     grid-area: c;
+    overflow: scroll;
   }
 
   &__content {


### PR DESCRIPTION
Several things are sub-par in the current implementation:
- The `$size` event is triggered using an interval
- Size is based on the document element

This PR refactors the way we trigger the `$size` event and how we calculate the size itself:
- Replaces interval-based size update with a `ResizeObserver` instance.
- Uses the body element to measure size, to avoid issues that come with using the document element

Also added `"overflow:scroll"` to the View widget's content holder element, so we have a behaviour more in line with the Connect SPA.

These changes are backwards compatible, since there is no external API to mess with the `$size` event, so no need to update the major version after this is merged.