### PR TITLE
Add "fullWidth" prop to the Menu widget

### DIFF
--- a/components/src/stories/Menu.stories.js
+++ b/components/src/stories/Menu.stories.js
@@ -16,8 +16,8 @@ export const Component = {
           slot="trigger" 
           text="open menu" 
         />
-        <div style="padding:8px 16px; width:300px; border:1px solid black;" slot="content">
-          <p>item</p>
+        <div style="padding:8px 16px; border:1px solid black;" slot="content">
+          <p>Lorem ipsum dolor sit amet</p>
         </div>
       </ui-menu>
     `
@@ -25,6 +25,8 @@ export const Component = {
 
   args: {
     align: 'left',
+    closeOnClickInside: false,
+    fullWidth: false,
   },
 };
 
@@ -36,6 +38,8 @@ export default {
   },
 
   argTypes: {
+    closeOnClickInside: 'boolean',
+    fullWidth: 'boolean',
     align: {
       options: ['right', 'left'],
       control: {

--- a/components/src/widgets/menu/widget.spec.js
+++ b/components/src/widgets/menu/widget.spec.js
@@ -119,6 +119,34 @@ describe('Menu component', () => {
     });
   });
 
+  describe('fullWidth class', () => {
+    it('adds the "menu-content_full-width" class if fullWidth is true', async () => {
+      const wrapper = mount(Menu, {
+        props: {
+          fullWidth: true,
+        },
+      });
+
+      // Open menu
+      await wrapper.find('.menu-trigger').trigger('click');
+
+      expect(wrapper.find('.menu-content_full-width').exists()).toEqual(true);
+    });
+
+    it('does not add the "menu-content_full-width" class fullWidth is false', async () => {
+      const wrapper = mount(Menu, {
+        props: {
+          fullWidth: false,
+        },
+      });
+
+      // Open menu
+      await wrapper.find('.menu-trigger').trigger('click');
+
+      expect(wrapper.find('.menu-content_full-width').exists()).toEqual(false);
+    });
+  });
+
   describe('align prop validator', () => {
     it.each([
       // expected, value

--- a/components/src/widgets/menu/widget.vue
+++ b/components/src/widgets/menu/widget.vue
@@ -14,7 +14,7 @@
       <div
         v-if="showMenu"
         class="menu-content"
-        :class="alignmentClass"
+        :class="[alignmentClass, fullWidthClass]"
         @click.stop="onClickInside"
       >
         <slot name="content" />
@@ -38,6 +38,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  fullWidth: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const showMenu = ref(false);
@@ -47,6 +51,8 @@ const alignmentClass = computed(() => (props.align === 'left'
   ? 'menu-content_align-left'
   : 'menu-content_align-right'
 ));
+
+const fullWidthClass = computed(() => (props.fullWidth ? 'menu-content_full-width' : ''));
 
 const toggle = () => {
   showMenu.value = !showMenu.value;
@@ -80,12 +86,18 @@ onUnmounted(() => {
 .menu-content {
   position: absolute;
   top: 0;
+  width: max-content;
 
   &_align-right {
     right: 0;
   }
+
   &_align-left {
     left: 0;
+  }
+
+  &_full-width {
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
Added the `fullWidth` prop to the Menu widget, to work in cases like this screenshot:

<kbd><img width="500" alt="Screenshot 2024-02-27 at 13 51 54" src="https://github.com/cloudblue/connect-ui-toolkit/assets/50662025/49f91b31-bad0-4f6a-a7c3-8e3d3b50c36c"></kbd>
