### PR TITLE
LITE-30032: Add "required" prop to Select and TextField

### DIFF
--- a/components/src/stories/Select.stories.js
+++ b/components/src/stories/Select.stories.js
@@ -47,6 +47,7 @@ export const Validation = {
     hint: 'Select the second option if you want the validation to be successful',
     propValue: 'id',
     propText: 'name',
+    required: true,
     options: [
       { id: 'OBJ-123', name: 'The first object' },
       { id: 'OBJ-456', name: 'The second object' },
@@ -133,6 +134,7 @@ export default {
     hint: 'text',
     propValue: 'text',
     propText: 'text',
+    required: 'boolean',
     options: { control: 'array' },
   },
 };

--- a/components/src/stories/TextField.stories.js
+++ b/components/src/stories/TextField.stories.js
@@ -32,6 +32,7 @@ export const Validation = {
     hint: 'This is a text field with validation. The value should be an email',
     value: '',
     placeholder: 'john.doe@example.com',
+    required: true,
     rules: [
       (value) => !!value || 'This field is required',
       (value) => isEmail(value) || 'The value is not a valid email address',
@@ -50,5 +51,6 @@ export default {
     value: 'text',
     placeholder: 'text',
     suffix: 'text',
+    required: 'boolean',
   },
 };

--- a/components/src/widgets/select/widget.vue
+++ b/components/src/widgets/select/widget.vue
@@ -118,6 +118,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  required: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['valueChange']);
@@ -129,6 +133,7 @@ const isFocused = ref(false);
 const computedClasses = computed(() => ({
   'select-input_focused': isFocused.value,
   'select-input_invalid': !isValid.value,
+  'select-input_required': props.required,
 }));
 
 const computedOptions = computed(() =>
@@ -157,6 +162,14 @@ const getDisplayText = (item) => {
 <style lang="stylus" scoped>
 .select-input {
   color: #212121;
+
+  &_required .select-input__label p::after {
+    content: '*';
+    margin-left: 3px;
+    color: #FF0000;
+    text-decoration: none;
+    display: inline-block;
+  }
 
   &__selected {
     height: 44px;

--- a/components/src/widgets/textfield/widget.vue
+++ b/components/src/widgets/textfield/widget.vue
@@ -72,6 +72,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  required: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['input']);
@@ -86,6 +90,7 @@ const isFocused = ref(false);
 const computedClasses = computed(() => ({
   'text-field_focused': isFocused.value,
   'text-field_invalid': !isValid.value,
+  'text-field_required': props.required,
 }));
 
 const removeFocus = () => (isFocused.value = false);
@@ -124,6 +129,14 @@ watch(localValue, (newValue) => {
     font-weight 500;
     font-size: 14px;
     line-height: 1.4;
+  }
+
+  &_required label::after {
+    content: '*';
+    margin-left: 3px;
+    color: #FF0000;
+    text-decoration: none;
+    display: inline-block;
   }
 
   &__body {


### PR DESCRIPTION
The `required` prop adds the classic required asterisk:
![Screenshot 2024-04-17 at 18 05 35](https://github.com/cloudblue/connect-ui-toolkit/assets/50662025/547b3784-ecd5-4c40-808a-a9e80bfbd558)
