### PR TITLE
Add global styles for preview

### DIFF
--- a/.storybook/global-styles.css
+++ b/.storybook/global-styles.css
@@ -1,0 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import './global-styles.css';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {


### PR DESCRIPTION
Now preview iframe uses Roboto to as the default font family

<img width="1136" alt="Screenshot 2024-04-30 at 11 30 44" src="https://github.com/cloudblue/connect-ui-toolkit/assets/50662025/c4d6d003-5b01-495a-8eb5-522a955af2f3">
