### PR TITLE
Fix tools build as an ES module

### DIFF
--- a/tools/vite.config.js
+++ b/tools/vite.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   build: {
     emptyOutDir: false,
     lib: {
+      formats: ['es'],
       entry: {
         'fastApi/adapter': resolve(__dirname, 'api/fastApi/adapter.js'),
         'fastApi/vue-composable': resolve(__dirname, 'api/fastApi/vue-composable.js'),


### PR DESCRIPTION
Exports under tools build were not working after the package was updated to be an ES module